### PR TITLE
[issue #7] Introduce support to Python 3.x

### DIFF
--- a/pinject/arg_binding_keys_test.py
+++ b/pinject/arg_binding_keys_test.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import unittest
 
-from pinject import annotations
 from pinject import arg_binding_keys
 from pinject import binding_keys
 from pinject import provider_indirections

--- a/pinject/bindings.py
+++ b/pinject/bindings.py
@@ -14,12 +14,9 @@ limitations under the License.
 """
 
 
-import inspect
 import re
+import inspect
 import threading
-import types
-
-from .third_party import decorator
 
 from . import binding_keys
 from . import decorators
@@ -27,6 +24,7 @@ from . import errors
 from . import locations
 from . import providing
 from . import scoping
+from . import support
 
 
 class Binding(object):
@@ -181,8 +179,7 @@ def get_provider_bindings(
         get_arg_names_from_provider_fn_name=(
             providing.default_get_arg_names_from_provider_fn_name)):
     provider_bindings = []
-    fns = inspect.getmembers(binding_spec,
-                             lambda x: type(x) == types.MethodType)
+    fns = inspect.getmembers(binding_spec, lambda x: inspect.ismethod(x))
     for _, fn in fns:
         default_arg_names = get_arg_names_from_provider_fn_name(fn.__name__)
         fn_bindings = get_provider_fn_bindings(fn, default_arg_names)

--- a/pinject/decorators.py
+++ b/pinject/decorators.py
@@ -14,13 +14,12 @@ limitations under the License.
 """
 
 
-import collections
 import inspect
 
 from .third_party import decorator
 
 from . import arg_binding_keys
-from . import binding_keys
+from . import support
 from . import errors
 from . import locations
 from . import scoping
@@ -88,8 +87,8 @@ def inject(arg_names=None, all_except=None):
         if arg_value is not None:
             if not arg_value:
                 raise errors.EmptySequenceArgError(back_frame_loc, arg)
-            if (not isinstance(arg_value, collections.Sequence) or
-                isinstance(arg_value, basestring)):
+            if (not support.is_sequence(arg_value) or
+                    support.is_string(arg_value)):
                 raise errors.WrongArgTypeError(
                     arg, 'sequence (of arg names)', type(arg_value).__name__)
     if arg_names is None and all_except is None:
@@ -239,14 +238,14 @@ def _get_pinject_wrapper(
                 arg_binding_key)
         if (provider_arg_name is not None or
             provider_annotated_with is not None or
-            provider_in_scope_id is not None):
+                provider_in_scope_id is not None):
             provider_decorations = getattr(
                 pinject_decorated_fn, _PROVIDER_DECORATIONS_ATTR)
             provider_decorations.append(ProviderDecoration(
                 provider_arg_name, provider_annotated_with,
                 provider_in_scope_id))
         if (inject_arg_names is not None or
-            inject_all_except_arg_names is not None):
+                inject_all_except_arg_names is not None):
             if hasattr(pinject_decorated_fn, _NON_INJECTABLE_ARG_NAMES_ATTR):
                 raise errors.DuplicateDecoratorError('inject', decorator_loc)
             non_injectable_arg_names = []

--- a/pinject/decorators_test.py
+++ b/pinject/decorators_test.py
@@ -22,7 +22,6 @@ from pinject import bindings
 from pinject import binding_keys
 from pinject import decorators
 from pinject import errors
-from pinject import injection_contexts
 from pinject import scoping
 
 

--- a/pinject/errors.py
+++ b/pinject/errors.py
@@ -14,7 +14,7 @@ limitations under the License.
 """
 
 
-import locations
+from . import locations
 
 
 class Error(Exception):

--- a/pinject/initializers.py
+++ b/pinject/initializers.py
@@ -16,9 +16,11 @@ limitations under the License.
 
 import inspect
 
+
 from .third_party import decorator
 
 from . import errors
+from . import support
 
 
 def copy_args_to_internal_fields(fn):
@@ -49,7 +51,7 @@ def _copy_args_to_fields(fn, decorator_name, field_prefix):
     def CopyThenCall(fn_to_wrap, self, *pargs, **kwargs):
         for index, parg in enumerate(pargs, start=1):
             setattr(self, field_prefix + arg_names[index], parg)
-        for kwarg, kwvalue in kwargs.iteritems():
+        for kwarg, kwvalue in support.items(kwargs):
             setattr(self, field_prefix + kwarg, kwvalue)
         fn_to_wrap(self, *pargs, **kwargs)
     return decorator.decorator(CopyThenCall, fn)

--- a/pinject/object_graph.py
+++ b/pinject/object_graph.py
@@ -14,12 +14,8 @@ limitations under the License.
 """
 
 
-import collections
-import functools
 import inspect
-import types
 
-from . import arg_binding_keys
 from . import bindings
 from . import decorators
 from . import errors
@@ -30,6 +26,7 @@ from . import object_providers
 from . import providing
 from . import required_bindings as required_bindings_lib
 from . import scoping
+from . import support
 
 
 def new_object_graph(
@@ -81,21 +78,21 @@ def new_object_graph(
     """
     try:
         if modules is not None and modules is not finding.ALL_IMPORTED_MODULES:
-            _verify_types(modules, types.ModuleType, 'modules')
+            support.verify_module_types(modules, 'modules')
         if classes is not None:
-            _verify_types(classes, types.TypeType, 'classes')
+            support.verify_class_types(classes, 'classes')
         if binding_specs is not None:
-            _verify_subclasses(
+            support.verify_subclasses(
                 binding_specs, bindings.BindingSpec, 'binding_specs')
         if get_arg_names_from_class_name is not None:
-            _verify_callable(get_arg_names_from_class_name,
-                             'get_arg_names_from_class_name')
+            support.verify_callable(get_arg_names_from_class_name,
+                                    'get_arg_names_from_class_name')
         if get_arg_names_from_provider_fn_name is not None:
-            _verify_callable(get_arg_names_from_provider_fn_name,
-                             'get_arg_names_from_provider_fn_name')
+            support.verify_callable(get_arg_names_from_provider_fn_name,
+                                    'get_arg_names_from_provider_fn_name')
         if is_scope_usable_from_scope is not None:
-            _verify_callable(is_scope_usable_from_scope,
-                             'is_scope_usable_from_scope')
+            support.verify_callable(is_scope_usable_from_scope,
+                                    'is_scope_usable_from_scope')
         injection_context_factory = injection_contexts.InjectionContextFactory(
             is_scope_usable_from_scope)
         id_to_scope = scoping.get_id_to_scope_with_defaults(id_to_scope)
@@ -169,46 +166,10 @@ def new_object_graph(
         use_short_stack_traces)
 
 
-def _verify_type(elt, required_type, arg_name):
-    if type(elt) != required_type:
-        raise errors.WrongArgTypeError(
-            arg_name, required_type.__name__, type(elt).__name__)
-
-
-def _verify_types(seq, required_type, arg_name):
-    if not isinstance(seq, collections.Sequence):
-        raise errors.WrongArgTypeError(
-            arg_name, 'sequence (of {0})'.format(required_type.__name__),
-            type(seq).__name__)
-    for idx, elt in enumerate(seq):
-        if type(elt) != required_type:
-            raise errors.WrongArgElementTypeError(
-                arg_name, idx, required_type.__name__, type(elt).__name__)
-
-
-def _verify_subclasses(seq, required_superclass, arg_name):
-    if not isinstance(seq, collections.Sequence):
-        raise errors.WrongArgTypeError(
-            arg_name,
-            'sequence (of subclasses of {0})'.format(
-                required_superclass.__name__),
-            type(seq).__name__)
-    for idx, elt in enumerate(seq):
-        if not isinstance(elt, required_superclass):
-            raise errors.WrongArgElementTypeError(
-                arg_name, idx,
-                'subclass of {0}'.format(required_superclass.__name__),
-                type(elt).__name__)
-
-
-def _verify_callable(fn, arg_name):
-    if not callable(fn):
-        raise errors.WrongArgTypeError(arg_name, 'callable', type(fn).__name__)
-
-
 def _pare_to_present_args(kwargs, fn):
     arg_names, _, _, _ = inspect.getargspec(fn)
-    return {arg: value for arg, value in kwargs.iteritems() if arg in arg_names}
+    return {arg: value
+            for arg, value in support.items(kwargs) if arg in arg_names}
 
 
 class ObjectGraph(object):
@@ -231,7 +192,7 @@ class ObjectGraph(object):
         Raises:
           Error: an instance of cls is not providable
         """
-        _verify_type(cls, types.TypeType, 'cls')
+        support.verify_class_type(cls, 'cls')
         if not self._is_injectable_fn(cls):
             provide_loc = locations.get_back_frame_loc()
             raise errors.NonExplicitlyBoundClassError(provide_loc, cls)

--- a/pinject/object_graph_test.py
+++ b/pinject/object_graph_test.py
@@ -14,8 +14,6 @@ limitations under the License.
 """
 
 
-import inspect
-import types
 import unittest
 
 from pinject import bindings
@@ -228,68 +226,6 @@ class NewObjectGraphTest(unittest.TestCase):
                           object_graph.new_object_graph,
                           modules=None, classes=[Foo, _Foo],
                           binding_specs=[SomeBindingSpec()])
-
-
-class VerifyTypeTest(unittest.TestCase):
-
-    def test_verifies_correct_type_ok(self):
-        object_graph._verify_type(types, types.ModuleType, 'unused')
-
-    def test_raises_exception_if_incorrect_type(self):
-        self.assertRaises(errors.WrongArgTypeError, object_graph._verify_type,
-                          'not-a-module', types.ModuleType, 'an-arg-name')
-
-
-class VerifyTypesTest(unittest.TestCase):
-
-    def test_verifies_empty_sequence_ok(self):
-        object_graph._verify_types([], types.ModuleType, 'unused')
-
-    def test_verifies_correct_type_ok(self):
-        object_graph._verify_types([types], types.ModuleType, 'unused')
-
-    def test_raises_exception_if_not_sequence(self):
-        self.assertRaises(errors.WrongArgTypeError, object_graph._verify_types,
-                          42, types.ModuleType, 'an-arg-name')
-
-    def test_raises_exception_if_element_is_incorrect_type(self):
-        self.assertRaises(errors.WrongArgElementTypeError,
-                          object_graph._verify_types,
-                          ['not-a-module'], types.ModuleType, 'an-arg-name')
-
-
-class VerifySubclassesTest(unittest.TestCase):
-
-    def test_verifies_empty_sequence_ok(self):
-        object_graph._verify_subclasses([], bindings.BindingSpec, 'unused')
-
-    def test_verifies_correct_type_ok(self):
-        class SomeBindingSpec(bindings.BindingSpec):
-            pass
-        object_graph._verify_subclasses(
-            [SomeBindingSpec()], bindings.BindingSpec, 'unused')
-
-    def test_raises_exception_if_not_sequence(self):
-        self.assertRaises(errors.WrongArgTypeError,
-                          object_graph._verify_subclasses,
-                          42, bindings.BindingSpec, 'an-arg-name')
-
-    def test_raises_exception_if_element_is_not_subclass(self):
-        class NotBindingSpec(object):
-            pass
-        self.assertRaises(
-            errors.WrongArgElementTypeError, object_graph._verify_subclasses,
-            [NotBindingSpec()], bindings.BindingSpec, 'an-arg-name')
-
-
-class VerifyCallableTest(unittest.TestCase):
-
-    def test_verifies_callable_ok(self):
-        object_graph._verify_callable(lambda: None, 'unused')
-
-    def test_raises_exception_if_not_callable(self):
-        self.assertRaises(errors.WrongArgTypeError,
-                          object_graph._verify_callable, 42, 'an-arg-name')
 
 
 class PareToPresentArgsTest(unittest.TestCase):

--- a/pinject/object_providers.py
+++ b/pinject/object_providers.py
@@ -14,8 +14,7 @@ limitations under the License.
 """
 
 
-import types
-
+from . import support
 from . import arg_binding_keys
 from . import decorators
 from . import errors
@@ -61,7 +60,7 @@ class ObjectProvider(object):
 
     def provide_class(self, cls, injection_context,
                       direct_init_pargs, direct_init_kwargs):
-        if type(cls.__init__) is types.MethodType:
+        if support.is_constructor_defined(cls):
             init_pargs, init_kwargs = self.get_injection_pargs_kwargs(
                 cls.__init__, injection_context,
                 direct_init_pargs, direct_init_kwargs)

--- a/pinject/object_providers_test.py
+++ b/pinject/object_providers_test.py
@@ -14,11 +14,9 @@ limitations under the License.
 """
 
 
-import inspect
 import unittest
 
 from pinject import arg_binding_keys
-from pinject import binding_keys
 from pinject import bindings
 from pinject import decorators
 from pinject import errors
@@ -27,7 +25,7 @@ from pinject import object_providers
 from pinject import scoping
 
 
-def new_test_obj_provider(arg_binding_key, instance, allow_injecting_none=True):
+def new_obj_provider(arg_binding_key, instance, allow_injecting_none=True):
     binding_key = arg_binding_key.binding_key
     binding = bindings.new_binding_to_instance(
         binding_key, instance, 'a-scope', lambda: 'unused-desc')
@@ -50,7 +48,7 @@ class ObjectProviderTest(unittest.TestCase):
 
     def test_provides_from_arg_binding_key_successfully(self):
         arg_binding_key = arg_binding_keys.new('an-arg-name')
-        obj_provider = new_test_obj_provider(arg_binding_key, 'an-instance')
+        obj_provider = new_obj_provider(arg_binding_key, 'an-instance')
         self.assertEqual('an-instance',
                          obj_provider.provide_from_arg_binding_key(
                              _UNUSED_INJECTION_SITE_FN,
@@ -58,7 +56,7 @@ class ObjectProviderTest(unittest.TestCase):
 
     def test_provides_provider_fn_from_arg_binding_key_successfully(self):
         arg_binding_key = arg_binding_keys.new('provide_foo')
-        obj_provider = new_test_obj_provider(arg_binding_key, 'an-instance')
+        obj_provider = new_obj_provider(arg_binding_key, 'an-instance')
         provide_fn = obj_provider.provide_from_arg_binding_key(
             _UNUSED_INJECTION_SITE_FN,
             arg_binding_key, new_injection_context())
@@ -66,14 +64,14 @@ class ObjectProviderTest(unittest.TestCase):
 
     def test_can_provide_none_from_arg_binding_key_when_allowed(self):
         arg_binding_key = arg_binding_keys.new('an-arg-name')
-        obj_provider = new_test_obj_provider(arg_binding_key, None)
+        obj_provider = new_obj_provider(arg_binding_key, None)
         self.assertIsNone(obj_provider.provide_from_arg_binding_key(
             _UNUSED_INJECTION_SITE_FN,
             arg_binding_key, new_injection_context()))
 
     def test_cannot_provide_none_from_binding_key_when_disallowed(self):
         arg_binding_key = arg_binding_keys.new('an-arg-name')
-        obj_provider = new_test_obj_provider(arg_binding_key, None,
+        obj_provider = new_obj_provider(arg_binding_key, None,
                                              allow_injecting_none=False)
         self.assertRaises(errors.InjectingNoneDisallowedError,
                           obj_provider.provide_from_arg_binding_key,
@@ -85,7 +83,7 @@ class ObjectProviderTest(unittest.TestCase):
             def __init__(self, bar):
                 self.bar = bar
         arg_binding_key = arg_binding_keys.new('bar')
-        obj_provider = new_test_obj_provider(arg_binding_key, 'a-bar')
+        obj_provider = new_obj_provider(arg_binding_key, 'a-bar')
         foo = obj_provider.provide_class(Foo, new_injection_context(), [], {})
         self.assertEqual('a-bar', foo.bar)
 
@@ -94,7 +92,7 @@ class ObjectProviderTest(unittest.TestCase):
             @decorators.inject(['baz'])
             def __init__(self, foo, bar, baz):
                 self.foobarbaz = foo + bar + baz
-        obj_provider = new_test_obj_provider(arg_binding_keys.new('baz'), 'baz')
+        obj_provider = new_obj_provider(arg_binding_keys.new('baz'), 'baz')
         some_class = obj_provider.provide_class(
             SomeClass, new_injection_context(), ['foo'], {'bar': 'bar'})
         self.assertEqual('foobarbaz', some_class.foobarbaz)
@@ -103,7 +101,7 @@ class ObjectProviderTest(unittest.TestCase):
         class Foo(object):
             pass
         arg_binding_key = arg_binding_keys.new('unused')
-        obj_provider = new_test_obj_provider(arg_binding_key, 'unused')
+        obj_provider = new_obj_provider(arg_binding_key, 'unused')
         self.assertIsInstance(
             obj_provider.provide_class(Foo, new_injection_context(), [], {}),
             Foo)
@@ -112,7 +110,7 @@ class ObjectProviderTest(unittest.TestCase):
         def foo(bar):
             return 'a-foo-and-' + bar
         arg_binding_key = arg_binding_keys.new('bar')
-        obj_provider = new_test_obj_provider(arg_binding_key, 'a-bar')
+        obj_provider = new_obj_provider(arg_binding_key, 'a-bar')
         self.assertEqual('a-foo-and-a-bar',
                          obj_provider.call_with_injection(
                              foo, new_injection_context(), [], {}))
@@ -121,7 +119,7 @@ class ObjectProviderTest(unittest.TestCase):
         def foo(bar):
             pass
         arg_binding_key = arg_binding_keys.new('bar')
-        obj_provider = new_test_obj_provider(arg_binding_key, 'a-bar')
+        obj_provider = new_obj_provider(arg_binding_key, 'a-bar')
         pargs, kwargs = obj_provider.get_injection_pargs_kwargs(
             foo, new_injection_context(), [], {})
         self.assertEqual([], pargs)

--- a/pinject/support.py
+++ b/pinject/support.py
@@ -1,0 +1,91 @@
+"""Copyright 2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+import six
+import collections
+import inspect
+
+from . import errors
+
+
+def items(dict_instance):
+    return six.iteritems(dict_instance)
+
+
+def is_sequence(arg_value):
+    return isinstance(arg_value, collections.Sequence)
+
+
+def is_string(arg_value):
+    return isinstance(arg_value, six.string_types)
+
+
+def is_constructor_defined(cls):
+    if six.PY3:
+        return inspect.isfunction(cls.__init__)
+    return inspect.ismethod(cls.__init__)
+
+
+def verify_callable(fn, arg_name):
+    if not callable(fn):
+        raise errors.WrongArgTypeError(arg_name, 'callable', type(fn).__name__)
+
+
+def verify_subclasses(seq, required_superclass, arg_name):
+    if not isinstance(seq, collections.Sequence):
+        raise errors.WrongArgTypeError(
+            arg_name,
+            'sequence (of subclasses of {0})'.format(
+                required_superclass.__name__),
+            type(seq).__name__)
+    for idx, elt in enumerate(seq):
+        if not isinstance(elt, required_superclass):
+            raise errors.WrongArgElementTypeError(
+                arg_name, idx,
+                'subclass of {0}'.format(required_superclass.__name__),
+                type(elt).__name__)
+
+
+def verify_module_types(modules, arg_name):
+    _verify_types(inspect.ismodule, modules, arg_name, 'module')
+
+
+def verify_class_types(seq, arg_name):
+    _verify_types(inspect.isclass, seq, arg_name, 'class')
+
+
+def verify_class_type(elt, arg_name):
+    _verify_type(inspect.isclass, elt, arg_name, 'class')
+
+
+def _assert_sequence(seq, arg_name, type_name):
+    if not is_sequence(seq):
+        raise errors.WrongArgTypeError(
+            arg_name, 'sequence (of {0})'.format(type_name), type(seq).__name__)
+
+
+def _verify_types(fn_checker, seq, arg_name, type_name):
+    _assert_sequence(seq, arg_name, type_name)
+    for idx, elt in enumerate(seq):
+        if not fn_checker(elt):
+            raise errors.WrongArgElementTypeError(
+                arg_name, idx, type_name, type(elt).__name__)
+
+
+def _verify_type(fn_checker, elt, arg_name, type_name):
+    if not fn_checker(elt):
+        raise errors.WrongArgTypeError(
+            arg_name, type_name, type(elt).__name__)

--- a/pinject/support_test.py
+++ b/pinject/support_test.py
@@ -1,0 +1,142 @@
+"""Copyright 2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+import unittest
+import types
+import inspect
+
+from pinject import support
+from pinject import bindings
+from pinject import errors
+
+
+class VerifyTypeTest(unittest.TestCase):
+
+    def test_verifies_correct_type_ok(self):
+        support._verify_type(inspect.ismodule, types, 'unused', 'module')
+
+    def test_raises_exception_if_incorrect_type(self):
+        self.assertRaises(errors.WrongArgTypeError, support._verify_type,
+                          inspect.ismodule, 'not-a-module',
+                          'an-arg-name', 'module')
+
+
+class VerifyTypesTest(unittest.TestCase):
+
+    def test_verifies_empty_sequence_ok(self):
+        def fn_checker(elt):
+            return True
+        support._verify_types(fn_checker, [], 'unused', 'no_type')
+
+    def test_verifies_correct_type_ok(self):
+        support._verify_types(inspect.ismodule, [types], 'unused', 'module')
+
+    def test_raises_exception_if_not_sequence(self):
+        self.assertRaises(errors.WrongArgTypeError, support._verify_types,
+                          inspect.ismodule, 42, 'an-arg-name', 'module')
+
+    def test_raises_exception_if_element_is_incorrect_type(self):
+        self.assertRaises(errors.WrongArgElementTypeError,
+                          support._verify_types, inspect.ismodule,
+                          ['not-a-module'], 'an-arg-name', 'module')
+
+
+class VerifySubclassesTest(unittest.TestCase):
+
+    def test_verifies_empty_sequence_ok(self):
+        support.verify_subclasses([], bindings.BindingSpec, 'unused')
+
+    def test_verifies_correct_type_ok(self):
+        class SomeBindingSpec(bindings.BindingSpec):
+            pass
+        support.verify_subclasses(
+            [SomeBindingSpec()], bindings.BindingSpec, 'unused')
+
+    def test_raises_exception_if_not_sequence(self):
+        self.assertRaises(errors.WrongArgTypeError,
+                          support.verify_subclasses,
+                          42, bindings.BindingSpec, 'an-arg-name')
+
+    def test_raises_exception_if_element_is_not_subclass(self):
+        class NotBindingSpec(object):
+            pass
+        self.assertRaises(
+            errors.WrongArgElementTypeError, support.verify_subclasses,
+            [NotBindingSpec()], bindings.BindingSpec, 'an-arg-name')
+
+
+class VerifyCallableTest(unittest.TestCase):
+
+    def test_verifies_callable_ok(self):
+        support.verify_callable(lambda: None, 'unused')
+
+    def test_raises_exception_if_not_callable(self):
+        self.assertRaises(errors.WrongArgTypeError,
+                          support.verify_callable, 42, 'an-arg-name')
+
+
+class VerifyModuleTypesTest(unittest.TestCase):
+
+    def test_verifies_module_types_ok(self):
+        support.verify_module_types([types], 'unused')
+
+    def test_raises_exception_if_not_module_types(self):
+        self.assertRaises(errors.WrongArgTypeError,
+                          support.verify_module_types, 42, 'an-arg-name')
+
+
+class VerifyClassTypesTest(unittest.TestCase):
+
+    def test_verifies_module_types_ok(self):
+        class Foo(object):
+            pass
+        support.verify_class_types([Foo], 'unused')
+
+    def test_raises_exception_if_not_class_types(self):
+        self.assertRaises(errors.WrongArgTypeError,
+                          support.verify_class_types, 42, 'an-arg-name')
+
+
+class IsSequenceTest(unittest.TestCase):
+
+    def test_argument_identified_as_sequence_instance(self):
+        self.assertTrue(support.is_sequence(list()))
+
+    def test_argument_identified_as_not_sequence_instance(self):
+        self.assertFalse(support.is_sequence(None))
+
+
+class IsStringTest(unittest.TestCase):
+
+    def test_argument_identified_as_string_instance(self):
+        self.assertTrue(support.is_string('some string'))
+
+    def test_argument_identified_as_not_string_instance(self):
+        self.assertFalse(support.is_string(None))
+
+
+class IsConstructorDefinedTest(unittest.TestCase):
+
+    def test_constructor_present_detection(self):
+        class Foo(object):
+            def __init__(self):
+                pass
+        self.assertTrue(support.is_constructor_defined(Foo))
+
+    def test_constructor_not_present_detection(self):
+        class Foo(object):
+            pass
+        self.assertFalse(support.is_constructor_defined(Foo))

--- a/pinject/third_party/decorator.py
+++ b/pinject/third_party/decorator.py
@@ -31,11 +31,12 @@
 Decorator module, see http://pypi.python.org/pypi/decorator
 for the documentation.
 """
-
 __version__ = '3.4.0'
 
 __all__ = ["decorator", "FunctionMaker", "contextmanager"]
 
+
+import six
 import sys, re, inspect
 if sys.version >= '3':
     from inspect import getfullargspec
@@ -153,10 +154,10 @@ class FunctionMaker(object):
         try:
             code = compile(src, '<string>', 'single')
             # print >> sys.stderr, 'Compiling %s' % src
-            exec code in evaldict
+            six.exec_(code, evaldict)
         except:
-            print >> sys.stderr, 'Error in generated code:'
-            print >> sys.stderr, src
+            six.print_('Error in generated code:', file=sys.stderr)
+            six.print_(src, file=sys.stderr)
             raise
         func = evaldict[name]
         if addsource:
@@ -192,7 +193,7 @@ def decorator(caller, func=None):
     decorator(caller, func) decorates a function using a caller.
     """
     if func is not None: # returns a decorated function
-        evaldict = func.func_globals.copy()
+        evaldict = six.get_function_globals(func).copy()
         evaldict['_call_'] = caller
         evaldict['_func_'] = func
         return FunctionMaker.create(
@@ -216,7 +217,7 @@ def decorator(caller, func=None):
             callerfunc = caller.__call__.im_func
             doc = caller.__call__.__doc__
             fun = getfullargspec(callerfunc).args[1] # second arg
-        evaldict = callerfunc.func_globals.copy()
+        evaldict = six.get_function_globals(callerfunc).copy()
         evaldict['_call_'] = caller
         evaldict['decorator'] = decorator
         return FunctionMaker.create(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-from distutils.core import setup
+from setuptools import setup
 
 
 setup(name='pinject',
@@ -27,4 +27,5 @@ setup(name='pinject',
       license='Apache License 2.0',
       long_description=open('README.rst').read(),
       platforms='all',
-      packages=['pinject', 'pinject/third_party'])
+      packages=['pinject', 'pinject/third_party'],
+      install_requires=['six==1.7.3'])

--- a/test_errors.py
+++ b/test_errors.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 
+import six
 import inspect
 import sys
 import traceback
@@ -354,6 +355,6 @@ all_print_method_pairs = inspect.getmembers(
 all_print_method_pairs.sort(key=lambda x: x[0])
 all_print_methods = [value for name, value in all_print_method_pairs]
 for print_method in all_print_methods:
-    print '#' * 78
+    six.print_('#' * 78)
     print_method()
-print '#' * 78
+six.print_('#' * 78)


### PR DESCRIPTION
- Add Six package, a simple utilities for wrapping over differences
  between Python 2 and Python 3
- Encapsulate compatibility methods in 'support.py' module
- Introduce unit tests for 'support.py' module