### PR TITLE
Remove third_party package from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(name='pinject',
       license='Apache License 2.0',
       long_description=open('README.rst').read(),
       platforms='all',
-      packages=['pinject', 'pinject/third_party'],
+      packages=['pinject'],
       install_requires=['six>=1.7.3', 'decorator>=4.3.0'])


### PR DESCRIPTION
As this is no longer being used (now looks like it's in the requirements_dev.txt file instead). Can either remove from setup.py or add back the file in third_party folder to get builds working?